### PR TITLE
Yield

### DIFF
--- a/raft.go
+++ b/raft.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/armon/go-metrics"
@@ -153,6 +154,10 @@ type Raft struct {
 	// is indexed by an artificial ID which is used for deregistration.
 	observersLock sync.RWMutex
 	observers     map[uint64]*Observer
+
+	// suspendLeadership is a hint for Raft to not become a leader. This flag is bound by time, and can be used
+	// to control the identity of the leader in a (stable) group
+	suspendLeadership int64
 }
 
 // NewRaft is used to construct a new Raft node. It takes a configuration, as well
@@ -679,6 +684,10 @@ func (r *Raft) runFollower() {
 					didWarn = true
 				}
 			} else {
+				if atomic.LoadInt64(&r.suspendLeadership) == 1 {
+					r.logger.Printf(`[WARN] raft: Heartbeat timeout from %q reached, but leadership suspended. Will not enter Candidate mode`, lastLeader)
+					return
+				}
 				r.logger.Printf(`[WARN] raft: Heartbeat timeout from %q reached, starting election`, lastLeader)
 
 				metrics.IncrCounter([]string{"raft", "transition", "heartbeat_timeout"}, 1)
@@ -1931,5 +1940,19 @@ func (r *Raft) StepDown() error {
 		return fmt.Errorf("StepDown() is only applicable to the leader")
 	}
 	asyncNotifyCh(r.leaderState.stepDown)
+	return nil
+}
+
+// Yield instructs the node to not attempt becoming a leader in the
+// following duration.
+func (r *Raft) Yield() error {
+	atomic.StoreInt64(&r.suspendLeadership, 1)
+	yieldDuration := r.conf.HeartbeatTimeout * 5 // time enough for the yielded-to peer to become leader
+	go time.AfterFunc(yieldDuration, func() {
+		atomic.StoreInt64(&r.suspendLeadership, 0)
+	})
+	if r.getState() == Leader {
+		r.StepDown()
+	}
 	return nil
 }

--- a/raft.go
+++ b/raft.go
@@ -1925,7 +1925,11 @@ func (r *Raft) restoreSnapshot() error {
 }
 
 // StepDown instructs a leader to voluntarily step down, reentering election cycle.
-// Note that the node may yet win elections again
-func (r *Raft) StepDown() {
+// Note that the node may yet win elections again immediately following.
+func (r *Raft) StepDown() error {
+	if r.getState() != Leader {
+		return fmt.Errorf("StepDown() is only applicable to the leader")
+	}
 	asyncNotifyCh(r.leaderState.stepDown)
+	return nil
 }

--- a/raft.go
+++ b/raft.go
@@ -1923,3 +1923,9 @@ func (r *Raft) restoreSnapshot() error {
 	}
 	return nil
 }
+
+// StepDown instructs a leader to voluntarily step down, reentering election cycle.
+// Note that the node may yet win elections again
+func (r *Raft) StepDown() {
+	asyncNotifyCh(r.leaderState.stepDown)
+}


### PR DESCRIPTION
Storyline: https://github.com/hashicorp/raft/issues/218 

This combines https://github.com/hashicorp/raft/issues/219 and https://github.com/hashicorp/raft/pull/221

The `Yield()` function disables promotion for the running node, and in the event it is the leader, steps down.

This makes for a nicer flow than suggested by #220 or #221 thus closes them.